### PR TITLE
Item loading and remove home from menu

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Help Save Craigslist</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import Items from './components/Items'
 import { Amplify, Auth } from 'aws-amplify'
 import { CognitoIdToken } from 'amazon-cognito-identity-js'
 import settings from './aws-settings.json'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import {
   createTheme,
   colors,
@@ -18,8 +18,8 @@ import MessageList from './components/MessageList'
 import MessageDetail from './components/MessageDetail'
 import SingleItem from './components/SingleItem'
 import MessageNewMessage from './components/MessageNewMessage'
-import "@fontsource/inika" // https://fontsource.org/fonts/inika
-import "@fontsource/roboto"
+import '@fontsource/inika' // https://fontsource.org/fonts/inika
+import '@fontsource/roboto'
 
 // This object controls the Material UI theme overrides.
 // See here for how this object is structured:
@@ -33,33 +33,33 @@ const theme = createTheme({
     },
     secondary: {
       main: '#d5cde1',
-      light: '#efeef4'
+      light: '#efeef4',
     },
   },
   typography: {
-    fontFamily: "Inika",
+    fontFamily: 'Inika',
     h1: {
       fontSize: '5rem',
-      fontWeight: 700
+      fontWeight: 700,
     },
     h2: {
-      fontWeight: 700
+      fontWeight: 700,
     },
     h3: {
-      fontWeight: 700
+      fontWeight: 700,
     },
     body1: {
-      fontFamily: "Roboto",
-      fontSize: '1.25rem'
+      fontFamily: 'Roboto',
+      fontSize: '1.25rem',
     },
     body2: {
-      fontFamily: "Roboto",
-      fontSize: '1rem'
+      fontFamily: 'Roboto',
+      fontSize: '1rem',
     },
     button: {
-      fontSize: '1rem'
-    }
-  }
+      fontSize: '1rem',
+    },
+  },
 })
 
 // User authorization config
@@ -113,6 +113,7 @@ const App = () => {
             <NavBar user={user} />
             <Toolbar />
             <Routes>
+              <Route path='/' element={<Navigate to='/items' />} />
               <Route
                 path='/profile'
                 element={user && <Profile user={user} />}
@@ -120,9 +121,9 @@ const App = () => {
               <Route path='/items' element={<Items />} />
               <Route path='/items/item' element={<SingleItem />} />
               <Route path='/itemform' element={<ItemForm />} />
-              <Route path="/messages" element={<MessageList />} />
-              <Route path='/messageDetail' element={<MessageDetail/>} />
-              <Route path='/newMessage' element={<MessageNewMessage/>} />
+              <Route path='/messages' element={<MessageList />} />
+              <Route path='/messageDetail' element={<MessageDetail />} />
+              <Route path='/newMessage' element={<MessageNewMessage />} />
             </Routes>
           </BrowserRouter>
         </Container>

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import { CircularProgress, Grid } from '@mui/material'
 import ItemCard from './ItemCard'
 import { API } from 'aws-amplify'
 import { DashboardCustomizeOutlined } from '@mui/icons-material'
 
 export default function Items() {
   const [dbResponse, setDbResponse] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
 
   const fetchItems = async () => {
     const apiName = 'default'
@@ -14,6 +15,7 @@ export default function Items() {
     try {
       const response = await API.get(apiName, path, myInit)
       setDbResponse([...response.Items])
+      setLoading(false)
     } catch {
       console.error('Error fetching items')
     }
@@ -34,6 +36,11 @@ export default function Items() {
   return (
     <>
       <Grid container display={'flex'} spacing={3} justifyContent={'center'}>
+        {loading && (
+          <Grid item>
+            <CircularProgress />
+          </Grid>
+        )}
         {generateCards(dbResponse)}
       </Grid>
     </>

--- a/frontend/src/components/MenuDrawer.tsx
+++ b/frontend/src/components/MenuDrawer.tsx
@@ -12,7 +12,7 @@ import HomeRoundedIcon from '@mui/icons-material/HomeRounded'
 import SellRoundedIcon from '@mui/icons-material/SellRounded'
 import PersonRoundedIcon from '@mui/icons-material/PersonRounded'
 import ForumRoundedIcon from '@mui/icons-material/ForumRounded'
-import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded'
 import { CognitoIdToken } from 'amazon-cognito-identity-js'
 
 interface MenuDrawerProps {
@@ -38,12 +38,12 @@ export default function TemporaryDrawer(props: MenuDrawerProps) {
 
   return (
     <div>
-      <React.Fragment key="MenuButton">
+      <React.Fragment key='MenuButton'>
         <IconButton
-          size="large"
-          edge="start"
-          color="inherit"
-          aria-label="menu"
+          size='large'
+          edge='start'
+          color='inherit'
+          aria-label='menu'
           sx={{ mr: 2 }}
           onClick={toggleDrawer(true)}
         >
@@ -52,42 +52,36 @@ export default function TemporaryDrawer(props: MenuDrawerProps) {
         <Drawer open={state['open']} onClose={toggleDrawer(false)}>
           <Box
             sx={{ width: 250 }}
-            role="presentation"
+            role='presentation'
             onClick={toggleDrawer(false)}
             onKeyDown={toggleDrawer(false)}
           >
             <List>
-              <ListItem key="Home" disablePadding>
-                <ListItemButton component={Link} to="/">
-                  <HomeRoundedIcon sx={{ m: 1 }}></HomeRoundedIcon>
-                  <ListItemText primary="Home" />
-                </ListItemButton>
-              </ListItem>
-              <ListItem key="Items" disablePadding>
-                <ListItemButton component={Link} to="/items">
+              <ListItem key='Items' disablePadding>
+                <ListItemButton component={Link} to='/items'>
                   <SellRoundedIcon sx={{ m: 1 }}></SellRoundedIcon>
-                  <ListItemText primary="Items" />
+                  <ListItemText primary='Items' />
                 </ListItemButton>
               </ListItem>
-              <ListItem key="Messages" disablePadding>
-                <ListItemButton component={Link} to="/messages">
+              <ListItem key='Messages' disablePadding>
+                <ListItemButton component={Link} to='/messages'>
                   <ForumRoundedIcon sx={{ m: 1 }}></ForumRoundedIcon>
-                  <ListItemText primary="Messages" />
+                  <ListItemText primary='Messages' />
                 </ListItemButton>
               </ListItem>
               {props.user && (
-                <ListItem key="PostItem" disablePadding>
-                  <ListItemButton component={Link} to="/itemform">
+                <ListItem key='PostItem' disablePadding>
+                  <ListItemButton component={Link} to='/itemform'>
                     <AddCircleRoundedIcon sx={{ m: 1 }}></AddCircleRoundedIcon>
-                    <ListItemText primary="Post Item For Sale" />
+                    <ListItemText primary='Post Item For Sale' />
                   </ListItemButton>
                 </ListItem>
               )}
               {props.user && (
-                <ListItem key="Profile" disablePadding>
-                  <ListItemButton component={Link} to="/profile">
+                <ListItem key='Profile' disablePadding>
+                  <ListItemButton component={Link} to='/profile'>
                     <PersonRoundedIcon sx={{ m: 1 }}></PersonRoundedIcon>
-                    <ListItemText primary="Profile" />
+                    <ListItemText primary='Profile' />
                   </ListItemButton>
                 </ListItem>
               )}


### PR DESCRIPTION
- Adds a loading spinner when loading the all items view
- Removes the "home" route from the menu
- Going to the base URL redirects to /items
- Changed the name of the project shown in the browser tab