### PR TITLE
Search by Tag/Category

### DIFF
--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -6,13 +6,11 @@ import CardMedia from '@mui/material/CardMedia'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { useNavigate } from 'react-router-dom'
+import Chip from '@mui/material/Chip'
 
-// TODO - map clicking on tag button to search for other items with that tag
-function mapTagsToButtons(tags: []) {
+function mapTagsToChips(tags: []) {
   return tags.map((obj: string) => (
-    <Button sx={{ mx: 0.25 }} size='small' variant='contained'>
-      {obj}
-    </Button>
+    <Chip variant='outlined' color='primary' sx={{ m: 0.3 }} label={obj} />
   ))
 }
 
@@ -35,13 +33,15 @@ export default function MediaCard({ data }: any) {
         alt='green iguana'
       />
       <CardContent sx={{ mb: -2 }}>
-        <Typography gutterBottom variant='h5' component='div'>
-          {data.Title}
+        <Typography marginBottom={1} variant='h5' component='div'>
+          {data.Title}, ${data.Price}
         </Typography>
-        {mapTagsToButtons(data.Tags)}
+        {mapTagsToChips(data.Tags)}
       </CardContent>
-      <CardActions>
+      <CardActions sx={{ p: '16px' }}>
         <Button
+          size='small'
+          variant='contained'
           onClick={() =>
             navigate(generateItemUrl(data.UserID, data.PostedDate))
           }
@@ -50,6 +50,7 @@ export default function MediaCard({ data }: any) {
         </Button>
         <Button
           size='small'
+          variant='contained'
           onClick={() =>
             navigate('/newMessage', {
               state: { userID: data.UserID, subject: data.Title },

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from 'react'
-import { CircularProgress, Grid } from '@mui/material'
+import { CircularProgress, Grid, TextField, Typography } from '@mui/material'
 import ItemCard from './ItemCard'
 import { API } from 'aws-amplify'
 import { DashboardCustomizeOutlined } from '@mui/icons-material'
+import Button from '@mui/material/Button'
+import MenuItem from '@mui/material/MenuItem'
 
 export default function Items() {
   const [dbResponse, setDbResponse] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
+  const [allTagOptions, setAllTagOptions] = useState([])
+  const [tagSearchSelection, setTagSearchSelection] = useState('')
 
   const fetchItems = async () => {
     const apiName = 'default'
@@ -21,20 +25,88 @@ export default function Items() {
     }
   }
 
+  const setTagOptions = async () => {
+    const apiName = 'default'
+    const path = 'items/tags'
+    const myInit = {}
+    try {
+      const avaliableTags = await API.get(apiName, path, myInit)
+      setAllTagOptions(avaliableTags)
+    } catch {
+      console.error('Error fetching tags: ')
+    }
+  }
+
   useEffect(() => {
     fetchItems()
+    setTagOptions()
   }, [])
 
   function generateCards(dbResponse: any) {
-    return dbResponse.map((obj: any) => (
-      <Grid item>
-        <ItemCard data={obj}></ItemCard>
-      </Grid>
-    ))
+    // Filtering happens if a tag is selected from dropdown
+    if (tagSearchSelection) {
+      let displayItems = dbResponse.filter((item) => {
+        return item.Tags.includes(tagSearchSelection)
+      })
+      if (displayItems.length === 0) {
+        return (
+          <>
+            <Typography variant='h4' sx={{ my: 8 }}>
+              No items with this tag.
+            </Typography>
+          </>
+        )
+      } else {
+        return displayItems.map((obj: any) => (
+          <Grid item>
+            <ItemCard data={obj}></ItemCard>
+          </Grid>
+        ))
+      }
+    } else {
+      return dbResponse.map((obj: any) => (
+        <Grid item>
+          <ItemCard data={obj}></ItemCard>
+        </Grid>
+      ))
+    }
   }
 
   return (
     <>
+      <Grid container sx={{ m: 2 }} alignItems='center'>
+        <Grid item xs={12} md={3}>
+          <TextField
+            id='filter-by-tag'
+            select
+            fullWidth
+            label='Filter by Tag'
+            value={tagSearchSelection}
+            onChange={(e) => setTagSearchSelection(e.target.value)}
+            sx={{ minWidth: 100 }}
+            size='small'
+          >
+            {allTagOptions.map((t) => {
+              return (
+                <MenuItem key={t} value={t}>
+                  {t}
+                </MenuItem>
+              )
+            })}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} md={3}>
+          <Button
+            variant='contained'
+            color='secondary'
+            size='large'
+            sx={{ mx: 2, p: 1.25 }}
+            onClick={() => setTagSearchSelection('')}
+          >
+            Clear Selections
+          </Button>
+        </Grid>
+      </Grid>
       <Grid container display={'flex'} spacing={3} justifyContent={'center'}>
         {loading && (
           <Grid item>

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -77,10 +77,10 @@ export default function Items() {
       <Grid container sx={{ m: 2 }} alignItems='center'>
         <Grid item xs={12} md={3}>
           <TextField
-            id='filter-by-tag'
+            id='search-by-tag'
             select
             fullWidth
-            label='Filter by Tag'
+            label='Search by Tag'
             value={tagSearchSelection}
             onChange={(e) => setTagSearchSelection(e.target.value)}
             sx={{ minWidth: 100 }}


### PR DESCRIPTION
-Currently can only select one tag/category at a time to filter on. The actual project requirement is "search by tag" and I think this accomplishes that. Possibly consider multi-select as a stretch goal. 
-Minor UI updates to all-items view including changing the categories listed on the item cards to chips rather than buttons because they are informative, not actionable/clickable (could be another stretch goal to have these click-to-search, though)