### PR TITLE
Conditionally render "message seller", add search by location, add update of preferred_username

### DIFF
--- a/backend/profile.py
+++ b/backend/profile.py
@@ -1,0 +1,72 @@
+
+import json
+import boto3
+import os
+
+def lambda_handler(event, context):
+
+    def build_success_response(data):
+      return {
+        'statusCode': 200,
+        'headers': {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Headers': '*, Authorization',
+            'Access-Control-Allow-Origin': '*'
+        },
+        'body': json.dumps(data),
+        "isBase64Encoded": False
+    }
+
+    def build_failure_response(message):
+      return {
+        'statusCode': 400,
+        'headers': {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Headers': '*, Authorization',
+            'Access-Control-Allow-Origin': '*'
+        },
+        'body': message,
+        "isBase64Encoded": False
+    }
+
+    print(json.dumps(event))
+
+    client = boto3.client('cognito-idp')
+    user_pool_id = os.environ['USER_POOL_ID']
+
+    # The post method updates a preferred_username
+    if event['httpMethod'] == 'POST':
+      body = json.loads(event['body'])
+      preferred_username = body['username']
+      current_user = event['requestContext']['authorizer']['claims']['cognito:username']
+
+      try:
+        response = client.admin_update_user_attributes(
+          UserPoolId=user_pool_id,
+          Username=current_user,
+          UserAttributes=[
+              {
+                  'Name': 'preferred_username',
+                  'Value': preferred_username
+              },
+          ]
+        )
+
+        print(response)
+        return build_success_response(response)
+      except:
+        build_failure_response('error updating username')
+
+    # The get method gives the preferred_username given the cognito:username
+    if event['httpMethod'] == 'GET':
+      username = event['queryStringParameters']['user']
+      response = client.admin_get_user(
+        UserPoolId=user_pool_id,
+        Username=username
+      )
+      
+      for attribute in response['UserAttributes']:
+        if attribute['Name'] == 'preferred_username':
+          return build_success_response(attribute['Value'])
+      
+      return build_success_response(None)

--- a/frontend/src/components/GenerateCards.tsx
+++ b/frontend/src/components/GenerateCards.tsx
@@ -7,6 +7,7 @@ function applyFilters(
   tagSearchSelection: string,
   priceSortSelection: string,
   dateSortSelection: string,
+  locationSearchSelection: string,
   priceMinSelection: string,
   priceMaxSelection: string,
   searchString: string,
@@ -17,6 +18,7 @@ function applyFilters(
     !tagSearchSelection &&
     !priceSortSelection &&
     !dateSortSelection &&
+    !locationSearchSelection &&
     !priceMinSelection &&
     !priceMaxSelection &&
     !searchString &&
@@ -34,7 +36,23 @@ function applyFilters(
     let displayItems = JSON.parse(
       JSON.stringify(dbResponse)
     ) as typeof dbResponse
-    if (tagSearchSelection) {
+    if (tagSearchSelection && locationSearchSelection) {
+      displayItems = dbResponse.filter((item) => {
+        return (
+          item.Tags.includes(tagSearchSelection) &&
+          item.Location === locationSearchSelection
+        )
+      })
+      if (displayItems.length === 0) {
+        return (
+          <>
+            <Typography variant='h4' sx={{ my: 8 }}>
+              No items with this tag and location.
+            </Typography>
+          </>
+        )
+      }
+    } else if (tagSearchSelection) {
       displayItems = dbResponse.filter((item) => {
         return item.Tags.includes(tagSearchSelection)
       })
@@ -43,6 +61,19 @@ function applyFilters(
           <>
             <Typography variant='h4' sx={{ my: 8 }}>
               No items with this tag.
+            </Typography>
+          </>
+        )
+      }
+    } else if (locationSearchSelection) {
+      displayItems = dbResponse.filter((item) => {
+        return item.Location === locationSearchSelection
+      })
+      if (displayItems.length === 0) {
+        return (
+          <>
+            <Typography variant='h4' sx={{ my: 8 }}>
+              No items with this location.
             </Typography>
           </>
         )
@@ -205,6 +236,7 @@ export default function generateCards(
   tagSearchSelection: string,
   priceSortSelection: string,
   dateSortSelection: string,
+  locationSearchSelection: string,
   priceMinSelection: string,
   priceMaxSelection: string,
   searchString: string,
@@ -215,6 +247,7 @@ export default function generateCards(
     tagSearchSelection,
     priceSortSelection,
     dateSortSelection,
+    locationSearchSelection,
     priceMinSelection,
     priceMaxSelection,
     searchString,

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -7,6 +7,8 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { useNavigate } from 'react-router-dom'
 import Chip from '@mui/material/Chip'
+import { Auth } from 'aws-amplify'
+import { useState, useEffect } from 'react'
 
 function mapTagsToChips(tags: []) {
   return tags.map((obj: string) => (
@@ -29,7 +31,21 @@ function generateItemUrl(userID: string, postDate: string) {
 // Documentation at: https://mui.com/material-ui/react-card/
 export default function MediaCard({ data }: any) {
   const navigate = useNavigate()
+  const [user, setUser] = useState(null)
 
+  const getCurrentUser = async () => {
+    try {
+      const idToken = (await Auth.currentSession()).getIdToken()
+      setUser(idToken)
+    } catch {
+      setUser(null)
+    }
+  }
+  useEffect(() => {
+    getCurrentUser()
+  }, [])
+
+  console.log('tag user', user)
   return (
     <Card sx={{ maxWidth: 345, m: 1 }} key={data.PostedDate}>
       <CardMedia
@@ -54,17 +70,19 @@ export default function MediaCard({ data }: any) {
         >
           View Details
         </Button>
-        <Button
-          size='small'
-          variant='contained'
-          onClick={() =>
-            navigate('/newMessage', {
-              state: { userID: data.UserID, subject: data.Title },
-            })
-          }
-        >
-          Message Seller
-        </Button>
+        {user && user.payload['cognito:username'] !== data.UserID && (
+          <Button
+            size='small'
+            variant='contained'
+            onClick={() =>
+              navigate('/newMessage', {
+                state: { userID: data.UserID, subject: data.Title },
+              })
+            }
+          >
+            Message Seller
+          </Button>
+        )}
       </CardActions>
     </Card>
   )

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -10,7 +10,13 @@ import Chip from '@mui/material/Chip'
 
 function mapTagsToChips(tags: []) {
   return tags.map((obj: string) => (
-    <Chip variant='outlined' color='primary' sx={{ m: 0.3 }} label={obj} />
+    <Chip
+      variant='outlined'
+      color='primary'
+      sx={{ m: 0.3 }}
+      label={obj}
+      key={obj}
+    />
   ))
 }
 
@@ -25,7 +31,7 @@ export default function MediaCard({ data }: any) {
   const navigate = useNavigate()
 
   return (
-    <Card sx={{ maxWidth: 345, m: 1 }}>
+    <Card sx={{ maxWidth: 345, m: 1 }} key={data.PostedDate}>
       <CardMedia
         component='img'
         height='140'

--- a/frontend/src/components/ItemCard.tsx
+++ b/frontend/src/components/ItemCard.tsx
@@ -45,7 +45,6 @@ export default function MediaCard({ data }: any) {
     getCurrentUser()
   }, [])
 
-  console.log('tag user', user)
   return (
     <Card sx={{ maxWidth: 345, m: 1 }} key={data.PostedDate}>
       <CardMedia

--- a/frontend/src/components/Items.tsx
+++ b/frontend/src/components/Items.tsx
@@ -9,7 +9,9 @@ export default function Items() {
   const [dbResponse, setDbResponse] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [allTagOptions, setAllTagOptions] = useState([])
+  const [allLocationOptions, setAllLocationOptions] = useState([])
   const [tagSearchSelection, setTagSearchSelection] = useState('')
+  const [locationSearchSelection, setLocationSearchSelection] = useState('')
   const [priceSortSelection, setPriceSortSelection] = useState('')
   const [dateSortSelection, setDateSortSelection] = useState('')
   const [priceMinSelection, setPriceMinSelection] = useState('')
@@ -42,15 +44,28 @@ export default function Items() {
     }
   }
 
+  const setLocationOptions = async () => {
+    const apiName = 'default'
+    const path = 'items/locations'
+    const myInit = {}
+    try {
+      const avaliableLocations = await API.get(apiName, path, myInit)
+      setAllLocationOptions(avaliableLocations)
+    } catch {
+      console.error('Error fetching locations: ')
+    }
+  }
+
   useEffect(() => {
     fetchItems()
     setTagOptions()
+    setLocationOptions()
   }, [])
 
   return (
     <>
       <Grid container sx={{ m: 2 }} alignItems='center'>
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12} md={3}>
           <TextField
             id='search-by-tag'
             select
@@ -70,7 +85,27 @@ export default function Items() {
             })}
           </TextField>
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12} md={3}>
+          <TextField
+            id='search-by-tag'
+            select
+            fullWidth
+            label='Search by Location'
+            value={locationSearchSelection}
+            onChange={(e) => setLocationSearchSelection(e.target.value)}
+            sx={{ minWidth: 100, mb: 1 }}
+            size='small'
+          >
+            {allLocationOptions.map((t) => {
+              return (
+                <MenuItem key={t} value={t}>
+                  {t}
+                </MenuItem>
+              )
+            })}
+          </TextField>
+        </Grid>
+        <Grid item xs={12} md={3}>
           <TextField
             id='sort-by-price'
             select
@@ -92,7 +127,7 @@ export default function Items() {
             })}
           </TextField>
         </Grid>
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12} md={3}>
           <TextField
             id='sort-by-date'
             select
@@ -161,8 +196,8 @@ export default function Items() {
             size='small'
             sx={{ mx: 1.5, p: 1.25, mb: 1 }}
             onClick={() => {
-              setSearchReady(true)}
-            }
+              setSearchReady(true)
+            }}
           >
             Search
           </Button>
@@ -176,6 +211,7 @@ export default function Items() {
             sx={{ p: 1.25, mb: 1 }}
             onClick={() => {
               setTagSearchSelection('')
+              setLocationSearchSelection('')
               setPriceSortSelection('')
               setDateSortSelection('')
               setPriceMinSelection('')
@@ -199,9 +235,10 @@ export default function Items() {
           tagSearchSelection,
           priceSortSelection,
           dateSortSelection,
+          locationSearchSelection,
           priceMinSelection,
           priceMaxSelection,
-          searchString, 
+          searchString,
           searchReady
         )}
       </Grid>

--- a/frontend/src/components/SingleItem.tsx
+++ b/frontend/src/components/SingleItem.tsx
@@ -123,20 +123,24 @@ export default function SingleItem(props: SingleItemProps) {
           <Typography variant='h1' gutterBottom>
             ${itemPrice}
           </Typography>
-          <IconButton
-            onClick={() =>
-              navigate('/newMessage', {
-                state: { userID: itemUser, subject: itemTitle },
-              })
-            }
-          >
-            <ForumRoundedIcon
-              sx={{ fontSize: 40, color: 'primary.main' }}
-            ></ForumRoundedIcon>
-          </IconButton>
-          <Typography variant='h5' sx={{ display: 'inline' }}>
-            Message Seller
-          </Typography>
+          {props.user?.payload['cognito:username'] !== user && (
+            <>
+              <IconButton
+                onClick={() =>
+                  navigate('/newMessage', {
+                    state: { userID: itemUser, subject: itemTitle },
+                  })
+                }
+              >
+                <ForumRoundedIcon
+                  sx={{ fontSize: 40, color: 'primary.main' }}
+                ></ForumRoundedIcon>
+              </IconButton>
+              <Typography variant='h5' sx={{ display: 'inline' }}>
+                Message Seller
+              </Typography>
+            </>
+          )}
         </Grid>
 
         {/* Item Photo */}

--- a/infrastructure/lib/stacks/apiStack.ts
+++ b/infrastructure/lib/stacks/apiStack.ts
@@ -102,18 +102,6 @@ export class APIStack extends Stack {
       removalPolicy: RemovalPolicy.DESTROY,
     })
 
-    itemsDatabase.addGlobalSecondaryIndex({
-      indexName: 'location-date-gsi',
-      partitionKey: {
-        name: 'Location',
-        type: AttributeType.STRING,
-      },
-      sortKey: {
-        name: 'PostedDate',
-        type: AttributeType.STRING,
-      },
-    })
-
     // Static images bucket and distribution
     const imagesBucket = new Bucket(this, 'imagesBucket', {})
 


### PR DESCRIPTION
- Conditionally render the "message seller" options in single item and all items view
- Add search by location functionality
- Removed the GSI on Items table (it wasn't being used and is unnecessary)
- Added /profile endpoint and lambda function
- Can update preferred_username in the "profile" component
- Can get a users preferred_username by sending "GET" request with "cognito:username" in the "user" query string parameter
- I tested the GET preferred_username with postman, attached is an image of how this was tested
<img width="1789" alt="image" src="https://user-images.githubusercontent.com/16655939/202816325-e9efc227-22be-4777-b389-3935887baf3e.png">
